### PR TITLE
Urgent Fix for Naver Post

### DIFF
--- a/down/directory.py
+++ b/down/directory.py
@@ -62,7 +62,7 @@ class DirectoryHandler:
         if title and post_date_short and series:
             dirs = self._create_directory(directory_name, post_writer, series, f'{post_date_short} {title}')
         else:
-            dirs = self._create_directory(directory_name, 'krsite-dl')
+            dirs = self._create_directory(directory_name, post_writer, f'{post_date_short} {title}')
 
         DownloadHandler().downloader_naver(img_list, dirs, post_date)
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ If you like this project, please consider giving it a star! Thanks!
 > [!IMPORTANT]
 > 1. Make sure you have `aria2c` installed and executeable in your system's PATH.
 >
->   Install `aria2c`` from https://github.com/aria2/aria2
+>   Install `aria2c` from https://github.com/aria2/aria2
 >
 > 2. Make sure you have `python3` at least version 3.6 installed and executeable in your system's PATH.
 >


### PR DESCRIPTION
Naver Post without a series from now on will be handled correctly.

**For Example:**
**Naver Post with series will be downloaded on**
_/yourbasedir/Naver Post/writer/series/post/_

**Naver Post without series will be downloaded on**
_/yourbasedir/Naver Post/writer/post/_

**Naver Post without series, before this FIX.**
_/yourbasedir/Naver Post/krsite-dl/post_

**Note:**
If you have downloaded Naver Post without series, you can directly move it to the appropriate directory or just re-download it.